### PR TITLE
Add simple greeting endpoint

### DIFF
--- a/src/main/java/com/consistech/springboot_app/controller/GreetingController.java
+++ b/src/main/java/com/consistech/springboot_app/controller/GreetingController.java
@@ -1,0 +1,23 @@
+package com.consistech.springboot_app.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.consistech.springboot_app.service.GreetingService;
+
+@RestController
+@RequestMapping("/api/v1/greetings")
+public class GreetingController {
+
+    private final GreetingService greetingService;
+
+    public GreetingController(GreetingService greetingService) {
+        this.greetingService = greetingService;
+    }
+
+    @GetMapping
+    public String getGreeting() {
+        return greetingService.getGreetingMessage();
+    }
+}

--- a/src/main/java/com/consistech/springboot_app/service/GreetingService.java
+++ b/src/main/java/com/consistech/springboot_app/service/GreetingService.java
@@ -1,0 +1,11 @@
+package com.consistech.springboot_app.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class GreetingService {
+
+    public String getGreetingMessage() {
+        return "Selamat datang di aplikasi Spring Boot!";
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated greeting service that returns a static welcome message
- expose a `/api/v1/greetings` GET endpoint that serves the greeting via a new controller

## Testing
- `./mvnw -q -e -DskipTests=false test` *(fails: Maven wrapper cannot download Maven binaries in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3f346e008333a6ef5298c9b6d7e1